### PR TITLE
Correct the name of the language being referred in README.md to be JavaScript.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ sanitize('WHY AM I YELLING?')          // => 'why am i yelling?'
 sanitize('HEY: ThIs Is hArD tO rEaD!') // => 'hey: this is hard to read!'
 ```
 
-Lucky for us, Ruby comes with a built-in method to help us:
+Lucky for us, JavaScript comes with a built-in method to help us:
 [String.prototype.toLowerCase][docs-javascript-string-tolowercase].
 
 Integrate this method into current program so that the `Map` of results


### PR DESCRIPTION
In the README file text, In iteration 0.3, there's a mention of the `String.prototype.toLowerCase` function to be used in the implementation of the `sanitize` function. The language being referred isn't Ruby, but Javascript. This PR fixes this error in the documentation.